### PR TITLE
fix: update usb to ignore vagrant cert

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -3,3 +3,5 @@
 vagrant_version: 1.9.0
 
 vagrant_package_download_dir: /opt
+
+vagrant_validate_cert: no

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -26,7 +26,10 @@
           file: path={{vagrant_package_download_dir}} state=directory recurse=true
 
         - name: Download package if necessary
-          get_url: url={{_vagrant_params['url']}} dest={{vagrant_package_download_dir}}/{{_vagrant_params['package']}}
+          get_url: 
+            url: {{_vagrant_params['url']}} 
+            dest: {{vagrant_package_download_dir}}/{{_vagrant_params['package']}}
+            validate_certs: {{ vagrant_validate_cert }}
           when: (package_stat.stat.islnk is not defined) or (package_stat.stat.checksum != _vagrant_params['checksum'])
 
         - name: Check package checksum


### PR DESCRIPTION
Vagrant cert does not always match when via a proxy